### PR TITLE
Update Docker to Python 3.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
 env:
-  PYTHON_VERSION: "3.12"
+  PYTHON_VERSION: "3.13"
   NODE_VERSION: "18.x"
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.6.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.13-slim-bookworm
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.13-slim-bullseye
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Summary
- use Python 3.13 in Dockerfile
- use Python 3.13 in developer Dockerfile
- update CI to use Python 3.13

## Testing
- `pytest` *(fails: unrecognized arguments --cov)*
- `pip install pre-commit` *(fails: ProxyError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684524b924848325a12246d45f7302f7