### PR TITLE
Update install instructions for venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,26 @@ Want to help out with development, testing, and/or documentation? Great! As both
 ## Installation / Running the Matter Server
 
 - Endusers of Home Assistant, refer to the [Home Assistant documentation](https://www.home-assistant.io/integrations/matter/) how to run Matter in Home Assistant using the official Matter Server add-on, which is based on this project.
-
 - For running the server and/or client in your development environment, see the [Development documentation](DEVELOPMENT.md).
-
 - For running the Matter Server as a standalone docker container, see our instructions [here](docs/docker.md).
+
+To install and run the Matter Server from source using a Python virtual environment:
+
+```bash
+git clone https://github.com/79B0Y/python-matter-server.git
+cd python-matter-server
+python3 -m venv .venv
+source .venv/bin/activate
+pip install ".[server]"
+```
+
+After installation the server can be started with:
+
+```bash
+python -m matter_server.server
+```
+
+See the [Development documentation](DEVELOPMENT.md) for more information about running in a development environment or check the [Docker instructions](docs/docker.md) for running the server in a container.
 
 > [!NOTE]
 > Both Matter and this implementation are in an early state and features are probably missing or could be improved. See our [development notes](#development) how you can help out, with development and/or testing.


### PR DESCRIPTION
## Summary
- clarify Python virtual env install steps in README
- link to user's repo for cloning
- restore bullet list linking to Home Assistant docs and Docker instructions

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `pytest -k 'nothing'` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68452606da1c8325aa090c722291ff5a